### PR TITLE
Feat hash passwords

### DIFF
--- a/src/lib/request_handling/handle_login.php
+++ b/src/lib/request_handling/handle_login.php
@@ -10,8 +10,9 @@ function handle_login($username,$password){
                 if($r){
                     $user = $stmt->fetch(PDO::FETCH_ASSOC);
                     if($user){
-                        $pass = $user["password"];
-                        if($pass == $password){
+                        $hash = $user["password"];
+                        unset($user["password"]);
+                        if (password_verify($password, $hash)) {
                             $jwt = generate_jwt($db,$user);
                             return [
                                 'code' => 200,

--- a/src/public/register.php
+++ b/src/public/register.php
@@ -76,7 +76,7 @@ if (isset($_POST["username"]) && isset($_POST["email"]) && isset($_POST["passwor
         $register_req['response'] = $msg;
     
         //sending received form responses to rabbitMQ
-        $response = json_decode($rbMQc->send_request($$register_req), true);
+        $response = json_decode($rbMQc->send_request($register_req), true);
 
         //checking whether or not resgister was processed successfully/unsuccessfully
         switch($response['code']){

--- a/src/public/register.php
+++ b/src/public/register.php
@@ -63,7 +63,7 @@ if (isset($_POST["username"]) && isset($_POST["email"]) && isset($_POST["passwor
 
     //If there are no validation errors
     if(!$hasError){
-        
+        $hash = password_hash($password, PASSWORD_BCRYPT);
         //opening a rabbitMQclient connection
         global $rbMQc;
         $msg = "Sending register request";
@@ -72,7 +72,7 @@ if (isset($_POST["username"]) && isset($_POST["email"]) && isset($_POST["passwor
         $register_req = array();
         $register_req['type'] = 'register';
         $register_req['username'] = $username;
-        $register_req['password'] = $password;
+        $register_req['password'] = $hash;
         $register_req['response'] = $msg;
     
         //sending received form responses to rabbitMQ


### PR DESCRIPTION
### Description
Added hashing for passwords

**Register Logic w/ hash:**
- A user enters valid credentials into the form on register.php
- If valid (has no errors), the password is hashed, and the hash is added to the regist_req array as the value for 'password'
- Then, the register_req array is sent to rabbitMQserver.php where its processed through handle_register()
- Handle register enter the credentials into users table, including the hash
**Login Logic w/ hash:**
- User logins in
- if valid (has no errors) the login request array is built and sent to rabbitMQserver.php script
- It's processed through the handle_login() which take the password and uses the `password_verify($password, $hash)` if true then the login logic continues ~ verifies the password against the hash
- This might need to be updated later on to hide the user password from the rabbitMQserver.php script

### Code Snippets
register.php:
```php
    if(!$hasError){
        $hash = password_hash($password, PASSWORD_BCRYPT);
        //opening a rabbitMQclient connection
        global $rbMQc;
        $msg = "Sending register request";

         //sending received form responses to rabbitMQ
        $response = json_decode($rbMQc->send_request($register_req), true);
        //creating a register array to store values
        $register_req = array();
        $register_req['type'] = 'register';
        $register_req['username'] = $username;
        $register_req['password'] = $hash;
        $register_req['response'] = $msg;
        
        /* rest of code */
```
rabbitMQserver.php script:
```php
case "register": // password is now hashed password
            $response = handle_register($request["username"],$request["password"]);
            break;
```
handle_register.php:
```php
function handle_register($username,$password){
        $db = getDB();
        $stmt = $db->prepare('INSERT INTO testusers (username, password) VALUES(:username, :password)');

            try{ // maps username to username and password to HASHED password
                $stmt->execute([":username" => $username, ":password" => $password]);
                //echo "User registered: $username";
```
Then when logging in (login.php) and sending a login request to the rabbitMQserver.php handle_login is called:
hand_login.php:
```
function handle_login($username,$password){
        $db = getDB();
        $stmt = $db->prepare("SELECT id, username, password FROM testusers WHERE username = :username");

            try{
                $r = $stmt->execute([":username" => $username]);
                if($r){
                    $user = $stmt->fetch(PDO::FETCH_ASSOC);
                    if($user){
                        $hash = $user["password"];
                        unset($user["password"]);
                        if (password_verify($password, $hash)) {
                            $jwt = generate_jwt($db,$user);
```